### PR TITLE
Use inline FNV hash instead of murmur

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"sync"
 	"sync/atomic"
-
-	"github.com/spaolacci/murmur3"
 )
 
 type Cache struct {
@@ -16,7 +14,7 @@ type Cache struct {
 }
 
 func hashFunc(data []byte) uint64 {
-	return murmur3.Sum64(data)
+	return sum64(data)
 }
 
 // The cache size will be set to 512KB at minimum.

--- a/inline_fnva.go
+++ b/inline_fnva.go
@@ -1,0 +1,27 @@
+package freecache
+
+const (
+	offset64 uint64 = 14695981039346656037
+	prime64  uint64 = 1099511628211
+)
+
+// sum64 is an in-lined version of Go's built-in fnv 64a hash.
+// https://golang.org/pkg/hash/fnv/
+//
+// These lines of code are equivalent:
+//
+// hash := sum64(data)
+//
+// h := fnv.New64a()
+// h.Write(data)
+// hash := h.Sum64()
+//
+// but the former creates no allocations.
+func sum64(data []byte) uint64 {
+	hash := offset64
+	for _, c := range data {
+		hash ^= uint64(c)
+		hash *= prime64
+	}
+	return hash
+}

--- a/inline_fnva_test.go
+++ b/inline_fnva_test.go
@@ -1,0 +1,27 @@
+package freecache
+
+import (
+	"hash/fnv"
+	"testing"
+	"testing/quick"
+)
+
+func TestInlineFNV64aEquivalenceFuzz(t *testing.T) {
+	f := func(data []byte) bool {
+		// get standard library FNV hash:
+		h := fnv.New64a()
+		h.Write(data)
+		want := h.Sum64()
+
+		// get our inline FNV hash:
+		got := sum64(data)
+
+		return want == got
+	}
+	cfg := &quick.Config{
+		MaxCount: 100000,
+	}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
reasoning:
  - faster
  - avoids an external & third-party dependency
  - uses the same algorithm as the golang standard library

These are the benchmark numbers I get:

```
‹inline-fnv-hash› % go test . -bench=. -benchmem
BenchmarkCacheSet-8   	 5000000	       376 ns/op	     107 B/op	       0 allocs/op
BenchmarkMapSet-8     	 2000000	       666 ns/op	     212 B/op	       2 allocs/op
BenchmarkCacheGet-8   	 5000000	       373 ns/op	       8 B/op	       1 allocs/op
BenchmarkMapGet-8     	20000000	       148 ns/op	       0 B/op	       0 allocs/op
BenchmarkHashFunc-8   	200000000	         8.03 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/coocood/freecache	44.636s


‹master› % go test . -bench=. -benchmem
BenchmarkCacheSet-8   	 5000000	       386 ns/op	     107 B/op	       0 allocs/op
BenchmarkMapSet-8     	 2000000	       671 ns/op	     212 B/op	       2 allocs/op
BenchmarkCacheGet-8   	 5000000	       379 ns/op	       8 B/op	       1 allocs/op
BenchmarkMapGet-8     	10000000	       153 ns/op	       0 B/op	       0 allocs/op
BenchmarkHashFunc-8   	100000000	        17.4 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/coocood/freecache	31.103s
```

As you can see, it's not significantly faster when taken as a whole. I still think it's worth the benefit of not requiring an external dependency, and using the same algorithm as the standard library.