### PR TITLE
Add GetWithExpiration and GetIntWithExpiration

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -139,8 +139,9 @@ func TestGetWithExpiration(t *testing.T) {
 	if err != nil {
 		t.Error("err should be nil", err.Error())
 	}
-	time.Sleep(time.Second)
+
 	res, expiry, err := cache.GetWithExpiration(key)
+	time.Sleep(time.Second)
 	if err != nil {
 		t.Error("err should be nil", err.Error())
 	}
@@ -326,7 +327,7 @@ func TestInt64Key(t *testing.T) {
 	}
 	now := time.Now()
 	if expiry != uint32(now.Unix()+1) {
-		t.Errorf("Expiry should be two seconds in the future but was %v", now)
+		t.Errorf("Expiry should one second in the future but was %v", now)
 	}
 
 	affected := cache.DelInt(1)

--- a/cache_test.go
+++ b/cache_test.go
@@ -131,7 +131,7 @@ func TestOverwrite(t *testing.T) {
 
 }
 
-func TestGetWithExpiry(t *testing.T) {
+func TestGetWithExpiration(t *testing.T) {
 	cache := NewCache(1024)
 	key := []byte("abcd")
 	val := []byte("efgh")
@@ -397,6 +397,21 @@ func BenchmarkCacheGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		binary.LittleEndian.PutUint64(key[:], uint64(i))
 		cache.Get(key[:])
+	}
+}
+
+func BenchmarkCacheGetWithExpiration(b *testing.B) {
+	b.StopTimer()
+	cache := NewCache(256 * 1024 * 1024)
+	var key [8]byte
+	for i := 0; i < b.N; i++ {
+		binary.LittleEndian.PutUint64(key[:], uint64(i))
+		cache.Set(key[:], make([]byte, 8), 0)
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		binary.LittleEndian.PutUint64(key[:], uint64(i))
+		cache.GetWithExpiration(key[:])
 	}
 }
 


### PR DESCRIPTION
I found I needed to get TTLs and values a lot, together, and that in my case expiry was more useful than TTL (because TTL goes to 0 both when its expired and when it is unset).

This PR adds two methods that let you get the value, with a nearly free expiration.