### PR TITLE
fixes for various race conditions

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -388,7 +388,7 @@ func TestRace(t *testing.T) {
 	wg := sync.WaitGroup{}
 	var iters int64 = 1000
 
-	wg.Add(5)
+	wg.Add(6)
 	addFunc := func() {
 		var i int64
 		for i = 0; i < iters; i++ {
@@ -434,12 +434,20 @@ func TestRace(t *testing.T) {
 		}
 		wg.Done()
 	}
+	clearFunc := func() {
+		var i int64
+		for i = 0; i < iters; i++ {
+			cache.Clear()
+		}
+		wg.Done()
+	}
 
 	go addFunc()
 	go getFunc()
 	go delFunc()
 	go evacFunc()
 	go resetFunc()
+	go clearFunc()
 	wg.Wait()
 }
 

--- a/segment.go
+++ b/segment.go
@@ -373,3 +373,23 @@ func (seg *segment) resetStatistics() {
 	atomic.StoreInt64(&seg.hitCount, 0)
 	atomic.StoreInt64(&seg.missCount, 0)
 }
+
+func (seg *segment) clear() {
+	bufSize := len(seg.rb.data)
+	seg.rb = NewRingBuf(bufSize, 0)
+	seg.vacuumLen = int64(bufSize)
+	seg.slotCap = 1
+	seg.slotsData = make([]entryPtr, 256*seg.slotCap)
+	for i := 0; i < len(seg.slotLens); i++ {
+		seg.slotLens[i] = 0
+	}
+
+	atomic.StoreInt64(&seg.hitCount, 0)
+	atomic.StoreInt64(&seg.missCount, 0)
+	atomic.StoreInt64(&seg.entryCount, 0)
+	atomic.StoreInt64(&seg.totalCount, 0)
+	atomic.StoreInt64(&seg.totalTime, 0)
+	atomic.StoreInt64(&seg.totalEvacuate, 0)
+	atomic.StoreInt64(&seg.totalExpired, 0)
+	atomic.StoreInt64(&seg.overwrites, 0)
+}


### PR DESCRIPTION
I was running some code that uses freecache with: go test -race
I noticed there were a few race conditions and I wanted to know if it was the freecache or the other code. So I wrote TestRace. That brought up the issues in freecache alone. I fixed most of the issues, but had to leave cache.Clear alone because I don't see how it can be fixed without a major re-org of the code. I also flipped cache.locks to a RWMutex, which should hopefully have a decnt performance benefit for work loads with more reads than writes.