### PR TITLE
fixes datarace on cache.TTL method

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -71,7 +71,9 @@ func (cache *Cache) GetWithExpiration(key []byte) (value []byte, expireAt uint32
 func (cache *Cache) TTL(key []byte) (timeLeft uint32, err error) {
 	hashVal := hashFunc(key)
 	segId := hashVal & 255
+	cache.locks[segId].Lock()
 	timeLeft, err = cache.segments[segId].ttl(key, hashVal)
+	cache.locks[segId].Unlock()
 	return
 }
 


### PR DESCRIPTION
There is a data race when fetching the TTL with concurrent mutations against the cache.


```
=== RUN   TestConcurrentGetTTL
==================
WARNING: DATA RACE
Read at 0x00c000123f00 by goroutine 6:
  github.com/deckarep/freecache.(*RingBuf).EqualAt()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/ringbuf.go:130 +0x5b
  github.com/deckarep/freecache.(*segment).lookup()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/segment.go:346 +0x193
  github.com/deckarep/freecache.(*segment).ttl()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/segment.go:249 +0x1c6
  github.com/deckarep/freecache.(*Cache).TTL()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/cache.go:74 +0xa0
  github.com/deckarep/freecache.TestConcurrentGetTTL()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/cache_test.go:586 +0x191
  testing.tRunner()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:827 +0x162

Previous write at 0x00c000123f00 by goroutine 59:
  github.com/deckarep/freecache.(*RingBuf).Write()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/ringbuf.go:90 +0x1ba
  github.com/deckarep/freecache.(*segment).set()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/segment.go:144 +0x700
  github.com/deckarep/freecache.(*Cache).Set()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/cache.go:46 +0x122
  github.com/deckarep/freecache.TestConcurrentGetTTL.func1()
      /Users/deckarep/gosource/src/github.com/deckarep/freecache/cache_test.go:581 +0x116

Goroutine 6 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:878 +0x650
  testing.runTests.func1()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:827 +0x162
  testing.runTests()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:80 +0x221
==================
--- FAIL: TestConcurrentGetTTL (0.09s)
    testing.go:771: race detected during execution of test
FAIL
exit status 1
FAIL	github.com/deckarep/freecache	0.113s
```