### PR TITLE
Adding Concurrent Benchmarks and Tests Issue #54

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -585,6 +585,7 @@ func BenchmarkParallelCacheGet(b *testing.B) {
 		cache.Set(key[:], buf, 0)
 	}
 	b.StartTimer()
+
 	b.RunParallel(func(pb *testing.PB) {
 		counter := 0
 		b.ReportAllocs()
@@ -624,6 +625,7 @@ func BenchmarkParallelCacheGetWithBuf(b *testing.B) {
 		cache.Set(key[:], buf, 0)
 	}
 	b.StartTimer()
+
 	b.RunParallel(func(pb *testing.PB) {
 		counter := 0
 		b.ReportAllocs()

--- a/cache_test.go
+++ b/cache_test.go
@@ -492,6 +492,38 @@ func TestRace(t *testing.T) {
 	wg.Wait()
 }
 
+func TestConcurrentSet(t *testing.T) {
+	var wg sync.WaitGroup
+	cache := NewCache(256 * 1024 * 1024)
+	N := 4000
+	routines := 50
+	wg.Add(routines)
+	for k := 0; k < routines; k++ {
+		go func(fact int) {
+			defer wg.Done()
+			for i := N * fact; i < (fact+1)*N; i++ {
+				var key, value [8]byte
+
+				binary.LittleEndian.PutUint64(key[:], uint64(i))
+				binary.LittleEndian.PutUint64(value[:], uint64(i*2))
+				cache.Set(key[:], value[:], 0)
+			}
+		}(k)
+	}
+	wg.Wait()
+	for i := 0; i < routines*N; i++ {
+		var key, value [8]byte
+
+		binary.LittleEndian.PutUint64(key[:], uint64(i))
+		cache.GetWithBuf(key[:], value[:])
+		var num uint64
+		binary.Read(bytes.NewBuffer(value[:]), binary.LittleEndian, &num)
+		if num != uint64(i*2) {
+			t.Fatalf("key %d not equal to %d", int(num), (i * 2))
+		}
+	}
+}
+
 func BenchmarkCacheSet(b *testing.B) {
 	cache := NewCache(256 * 1024 * 1024)
 	var key [8]byte
@@ -499,6 +531,21 @@ func BenchmarkCacheSet(b *testing.B) {
 		binary.LittleEndian.PutUint64(key[:], uint64(i))
 		cache.Set(key[:], make([]byte, 8), 0)
 	}
+}
+func BenchmarkParallelCacheSet(b *testing.B) {
+	cache := NewCache(256 * 1024 * 1024)
+	var key [8]byte
+
+	b.RunParallel(func(pb *testing.PB) {
+		counter := 0
+		b.ReportAllocs()
+
+		for pb.Next() {
+			binary.LittleEndian.PutUint64(key[:], uint64(counter))
+			cache.Set(key[:], make([]byte, 8), 0)
+			counter = counter + 1
+		}
+	})
 }
 
 func BenchmarkMapSet(b *testing.B) {
@@ -527,6 +574,28 @@ func BenchmarkCacheGet(b *testing.B) {
 	}
 }
 
+func BenchmarkParallelCacheGet(b *testing.B) {
+	b.ReportAllocs()
+	b.StopTimer()
+	cache := NewCache(256 * 1024 * 1024)
+	var key [8]byte
+	buf := make([]byte, 64)
+	for i := 0; i < b.N; i++ {
+		binary.LittleEndian.PutUint64(key[:], uint64(i))
+		cache.Set(key[:], buf, 0)
+	}
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		counter := 0
+		b.ReportAllocs()
+		for pb.Next() {
+			binary.LittleEndian.PutUint64(key[:], uint64(counter))
+			cache.Get(key[:])
+			counter = counter + 1
+		}
+	})
+}
+
 func BenchmarkCacheGetWithBuf(b *testing.B) {
 	b.ReportAllocs()
 	b.StopTimer()
@@ -542,6 +611,28 @@ func BenchmarkCacheGetWithBuf(b *testing.B) {
 		binary.LittleEndian.PutUint64(key[:], uint64(i))
 		cache.GetWithBuf(key[:], buf)
 	}
+}
+
+func BenchmarkParallelCacheGetWithBuf(b *testing.B) {
+	b.ReportAllocs()
+	b.StopTimer()
+	cache := NewCache(256 * 1024 * 1024)
+	var key [8]byte
+	buf := make([]byte, 64)
+	for i := 0; i < b.N; i++ {
+		binary.LittleEndian.PutUint64(key[:], uint64(i))
+		cache.Set(key[:], buf, 0)
+	}
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		counter := 0
+		b.ReportAllocs()
+		for pb.Next() {
+			binary.LittleEndian.PutUint64(key[:], uint64(counter))
+			cache.GetWithBuf(key[:], buf)
+			counter = counter + 1
+		}
+	})
 }
 
 func BenchmarkCacheGetWithExpiration(b *testing.B) {


### PR DESCRIPTION
@coocood I have added new benchmarks and got some really interesting results         
```
⫸  go test -v --bench=. -run=XXX
goos: darwin
goarch: amd64
pkg: github.com/Arafatk/freecache
BenchmarkCacheSet-4                      3000000               794 ns/op
BenchmarkParallelCacheSet-4              5000000               581 ns/op             121 B/op          0 allocs/op
BenchmarkMapSet-4                        2000000               806 ns/op
BenchmarkCacheGet-4                      2000000               629 ns/op              64 B/op          1 allocs/op
BenchmarkParallelCacheGet-4             10000000               113 ns/op               0 B/op          0 allocs/op
BenchmarkCacheGetWithBuf-4               3000000               538 ns/op               0 B/op          0 allocs/op
BenchmarkParallelCacheGetWithBuf-4      20000000               108 ns/op               0 B/op          0 allocs/op
BenchmarkCacheGetWithExpiration-4        3000000               601 ns/op
BenchmarkMapGet-4                       10000000               273 ns/op
BenchmarkHashFunc-4                     200000000                7.45 ns/op
PASS
ok      github.com/Arafatk/freecache    77.358s

```
Let me know what you think of this.    
Thanks 