### PR TITLE
Update README.md to make clear CacheSize definition usage 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ FreeCache should be many times faster than single lock protected built-in map.
 ## Example Usage
 
 ```go
+// In bytes, where 1024 * 1024 represents a single Megabyte, and 100 * 1024*1024 represents 100 Megabytes.
 cacheSize := 100 * 1024 * 1024
 cache := freecache.NewCache(cacheSize)
 debug.SetGCPercent(20)


### PR DESCRIPTION
Update README.md to make clear the cacheSize definition used, as this is not fully clear from the method signature (int).