### PR TITLE
README.md: avoid []byte -> string allocation/copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ got, err := cache.Get(key)
 if err != nil {
     fmt.Println(err)
 } else {
-    fmt.Println(string(got))
+    fmt.Printf("%s\n", got)
 }
 affected := cache.Del(key)
 fmt.Println("deleted key ", affected)


### PR DESCRIPTION
FreeCache invests a lot of effort to minimize GC overhead, yet the README example has a case where a (potentially very large) copy is made just as part of a `fmt.Println` call. With this change, it uses `fmt.Printf("%s\n", ...)`, which should be used in any case involving `Println` and a `[]byte` that's intended to be interpreted as string data.