### PR TITLE
Add atomic "Get and Set" method

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -22,6 +22,8 @@ type Cache struct {
 	segments [segmentCount]segment
 }
 
+type GetAndSetDecider func(value []byte, found bool) (newValue []byte, replace bool, expireSeconds int)
+
 func hashFunc(data []byte) uint64 {
 	return xxhash.Sum64(data)
 }
@@ -131,6 +133,32 @@ func (cache *Cache) SetAndGet(key, value []byte, expireSeconds int) (retValue []
 	retValue, _, err = cache.segments[segID].get(key, nil, hashVal, false)
 	if err == nil {
 		found = true
+	}
+	err = cache.segments[segID].set(key, value, hashVal, expireSeconds)
+	return
+}
+
+// GetAndSet gets value for a key, passes it do decider function that decides if set should be called as well
+// This allows for an atomic Get plus Set call using the existing value to decide on whether to call Set.
+// If the key is larger than 65535 or value is larger than 1/1024 of the cache size,
+// the entry will not be written to the cache. expireSeconds <= 0 means no expire,
+// but it can be evicted when cache is full. Returns bool value to indicate if existing record was found along with bool
+// value indicating the value was replaced and error if any
+func (cache *Cache) GetAndSet(key []byte, decider GetAndSetDecider) (found bool, replaced bool, err error) {
+	hashVal := hashFunc(key)
+	segID := hashVal & segmentAndOpVal
+	cache.locks[segID].Lock()
+	defer cache.locks[segID].Unlock()
+
+	retValue, _, err := cache.segments[segID].get(key, nil, hashVal, false)
+	if err == nil {
+		found = true
+	} else {
+		err = nil // Clear ErrNotFound error since we're returning found flag
+	}
+	value, replaced, expireSeconds := decider(retValue, found)
+	if !replaced {
+		return
 	}
 	err = cache.segments[segID].set(key, value, hashVal, expireSeconds)
 	return

--- a/cache_test.go
+++ b/cache_test.go
@@ -1018,8 +1018,8 @@ func TestSetAndGet(t *testing.T) {
 	}
 }
 
-func TestGetAndSet(t *testing.T) {
-	testName := "GetAndSet"
+func TestUpdate(t *testing.T) {
+	testName := "Update"
 	cache := NewCache(1024)
 	key := []byte("abcd")
 	val1 := []byte("efgh")
@@ -1027,18 +1027,18 @@ func TestGetAndSet(t *testing.T) {
 
 	var found, replaced bool
 	var err error
-	var prevVal, deciderVal []byte
-	deciderReplace := false
+	var prevVal, updaterVal []byte
+	updaterReplace := false
 	expireSeconds := 123
 
-	decider := func(value []byte, found bool) ([]byte, bool, int) {
+	updater := func(value []byte, found bool) ([]byte, bool, int) {
 		prevVal = value
-		return deciderVal, deciderReplace, expireSeconds
+		return updaterVal, updaterReplace, expireSeconds
 	}
 
-	setDeciderResponse := func(value []byte, replace bool) {
-		deciderVal = value
-		deciderReplace = replace
+	setUpdaterResponse := func(value []byte, replace bool) {
+		updaterVal = value
+		updaterReplace = replace
 	}
 
 	assertExpectations := func(testCase int, expectedFound, expectedReplaced bool, expectedPrevVal []byte, expectedVal []byte) {
@@ -1068,21 +1068,21 @@ func TestGetAndSet(t *testing.T) {
 	}
 
 	// Doesn't exist yet, decide not to update, set should not be called
-	found, replaced, err = cache.GetAndSet(key, decider)
+	found, replaced, err = cache.Update(key, updater)
 	assertExpectations(1, false, false, nil, nil)
 
 	// Doesn't exist yet, decide to update, set should be called with new value
-	setDeciderResponse(val1, true)
-	found, replaced, err = cache.GetAndSet(key, decider)
+	setUpdaterResponse(val1, true)
+	found, replaced, err = cache.Update(key, updater)
 	assertExpectations(2, false, true, nil, val1)
 
-	// Key exists, decide to update, decider is given old value and set should be called with new value
-	setDeciderResponse(val2, true)
-	found, replaced, err = cache.GetAndSet(key, decider)
+	// Key exists, decide to update, updater is given old value and set should be called with new value
+	setUpdaterResponse(val2, true)
+	found, replaced, err = cache.Update(key, updater)
 	assertExpectations(3, true, true, val1, val2)
 
-	// Key exists, decide not to update, decider is given old value and set should not be called
-	setDeciderResponse(val1, false)
-	found, replaced, err = cache.GetAndSet(key, decider)
+	// Key exists, decide not to update, updater is given old value and set should not be called
+	setUpdaterResponse(val1, false)
+	found, replaced, err = cache.Update(key, updater)
 	assertExpectations(4, true, false, val2, val2)
 }


### PR DESCRIPTION
- Adds an atomic Get plus Set method with a decider function to allow client to lookup value and decide on the new value (or leave as is).
- This would allow use cases like Incr, Decr as well as more complicated flows where setting the value depends on the current value.
