### PR TITLE
Add warning that Peek functions return expired values

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -165,6 +165,8 @@ func (cache *Cache) Update(key []byte, updater Updater) (found bool, replaced bo
 }
 
 // Peek returns the value or not found error, without updating access time or counters.
+// Warning: No expiry check is performed so if an expired value is found, it will be
+// returned without error
 func (cache *Cache) Peek(key []byte) (value []byte, err error) {
 	hashVal := hashFunc(key)
 	segID := hashVal & segmentAndOpVal
@@ -178,11 +180,13 @@ func (cache *Cache) Peek(key []byte) (value []byte, err error) {
 // provided function with slice view over the current underlying value of the
 // key in memory. The slice is constrained in length and capacity.
 //
-// In moth cases, this method will not alloc a byte buffer. The only exception
+// In most cases, this method will not alloc a byte buffer. The only exception
 // is when the value wraps around the underlying segment ring buffer.
 //
 // The method will return ErrNotFound is there's a miss, and the function will
 // not be called. Errors returned by the function will be propagated.
+// Warning: No expiry check is performed so if an expired value is found, it will be
+// returned without error
 func (cache *Cache) PeekFn(key []byte, fn func([]byte) error) (err error) {
 	hashVal := hashFunc(key)
 	segID := hashVal & segmentAndOpVal


### PR DESCRIPTION
Add warning to Peek() and PeekFn() functions documentation that these functions do not check expiry time of the value found in cache and will return the expired value without error 