### PR TITLE
fix: fix slice init length

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -509,7 +509,7 @@ func TestLargeEntry(t *testing.T) {
 	if err != ErrLargeEntry {
 		t.Error("err should be ErrLargeEntry", err)
 	}
-	val = make([]byte, maxValLen-2)
+	val = make([]byte, 0, maxValLen-2)
 	err = cache.Set(key, val, 0)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(staffCustomerIDs) rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW